### PR TITLE
Add zipfiles in project root to .gitignore

### DIFF
--- a/{{ cookiecutter.project_name }}/.gitignore
+++ b/{{ cookiecutter.project_name }}/.gitignore
@@ -134,6 +134,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+/*.zip
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION

When executing ``aws cloudformation package ...``` there will be a zipfile which should not be pushed to git.

*Description of changes:*

Exclude zipfile in project root folder (.gitignore). Not ignoring other zipfiles below the project root directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
