### PR TITLE
Remove shell step before pipenv installing in Makefile, it causes it …

### DIFF
--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -69,13 +69,11 @@ test: ##=> Run pytest
 
 _install_packages:
 	$(info [*] Install required packages...)
-	@$(PIPENV) shell \
-	&& @$(PIPENV) install
+	@$(PIPENV) install
 
 _install_dev_packages:
 	$(info [*] Install required dev-packages...)
-	@$(PIPENV) shell \
-	&& @$(PIPENV) install -d
+	@$(PIPENV) install -d
 
 _check_service_definition:
 	$(info [*] Checking whether service $(SERVICE) exists...)


### PR DESCRIPTION
…to stall and never finish

*Issue #18 
*Description of changes:*
The pipenv shell step seemed to now allow anything to continue, when exiting the shell it would fail the next step so nothing was installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
