### PR TITLE
Fix Makefile trying to recreate virtualenv constantly.

### DIFF
--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -8,7 +8,7 @@
 
 BASE := $(shell /bin/pwd)
 CODE_COVERAGE = 72
-PIPENV ?= pipenv --python 3.6
+PIPENV ?= pipenv
 
 ################# 
 #  Python vars	#

--- a/{{ cookiecutter.project_name }}/Pipfile
+++ b/{{ cookiecutter.project_name }}/Pipfile
@@ -17,3 +17,5 @@ aws-xray-sdk = "*"
 pytest = "*"
 pytest-cov = "*"
 
+[requires]
+python_version = "3.6"


### PR DESCRIPTION
Also adds requires python3.6 to the Pipfile. (which removes the need to specify the python version in the Makefile anyway)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
