### PR TITLE
do not run install within virtualenv shell

### DIFF
--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -72,13 +72,11 @@ test: ##=> Run pytest
 
 _install_packages:
 	$(info [*] Install required packages...)
-	@$(PIPENV) shell \
-	&& @$(PIPENV) install
+	@$(PIPENV) install
 
 _install_dev_packages:
 	$(info [*] Install required dev-packages...)
-	@$(PIPENV) shell \
-	&& @$(PIPENV) install -d
+	@$(PIPENV) install -d
 
 _check_service_definition:
 	$(info [*] Checking whether service $(SERVICE) exists...)


### PR DESCRIPTION
`make install` fails with the following error:

```
$ make install
[*] Install required packages...
Launching subshell in virtual environment…
sh-3.2$  . /Users/grigory/.local/share/virtualenvs/myproject-X9ld0cjB/bin/activate
(myproject) sh-3.2$ exit
/bin/sh: @pipenv: command not found
make: *** [_install_packages] Error 12
```

Do not try to run install within a shell.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.