### PR TITLE
Update project to target Python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.mypy_cache

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Cookiecutter SAM for Python Lambda functions
 
-This is a [Cookiecutter](https://github.com/audreyr/cookiecutter) template to create a Serverless App based on Serverless Application Model (SAM) and Python 3.6.
+This is a [Cookiecutter](https://github.com/audreyr/cookiecutter) template to create a Serverless App based on Serverless Application Model (SAM) and Python 3.8.
 
 It is important to note that you should not try to `git clone` this project but use `cookiecutter` CLI instead as ``{{cookiecutter.project_slug}}`` will be rendered based on your input and therefore all variables and files will be rendered properly.
 
 ## Requirements
 
-Install `cookiecutter` command line: 
+Install `cookiecutter` command line:
 
 **Pip users**:
 
@@ -24,7 +24,7 @@ Install `cookiecutter` command line:
 
 ## Usage
 
-Generate a new SAM based Serverless App: `cookiecutter gh:aws-samples/cookiecutter-aws-sam-python`. 
+Generate a new SAM based Serverless App: `cookiecutter gh:aws-samples/cookiecutter-aws-sam-python`.
 
 You'll be prompted a few questions to help this cookiecutter template to scaffold this project and after its completed you should see a new folder at your current path with the name of the project you gave as input.
 

--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -10,16 +10,16 @@ BASE := $(shell /bin/pwd)
 CODE_COVERAGE = 72
 PIPENV ?= pipenv
 
-################# 
+#################
 #  Python vars	#
-################# 
+#################
 
 SERVICE ?= service_not_defined
 EVENT ?= event_not_defined
 
-############# 
+#############
 #  SAM vars	#
-############# 
+#############
 
 NETWORK = ""
 
@@ -36,15 +36,15 @@ all: clean build
 
 install: _install_packages _install_dev_packages
 
-shell: 
+shell:
 	@$(PIPENV) shell
-	
+
 package: _check_service_definition ##=> Builds package using Docker Lambda container
 ifeq ($(DOCKER),1)
 	$(info [*] Cleaning up local dev/builds before build task...)
 	@$(MAKE) clean SERVICE="${SERVICE}"
 	$(info [+] Packaging service '$(SERVICE)' using Docker Lambda -- This may take a while...)
-	docker run -v $$PWD:/var/task -it lambci/lambda:build-python3.6 /bin/bash -c 'make _package SERVICE="${SERVICE}"'
+	docker run -v $$PWD:/var/task -it lambci/lambda:build-python3.8 /bin/bash -c 'make _package SERVICE="${SERVICE}"'
 else
 	$(info [*] Cleaning up local builds before build task...)
 	@$(MAKE) clean SERVICE="${SERVICE}"
@@ -66,9 +66,9 @@ run: ##=> Run SAM Local API GW and can optionally run new containers connected t
 test: ##=> Run pytest
 	@AWS_XRAY_CONTEXT_MISSING=LOG_ERROR $(PIPENV) run python -m pytest --cov . --cov-report term-missing --cov-fail-under $(CODE_COVERAGE) tests/ -v
 
-############# 
+#############
 #  Helpers  #
-############# 
+#############
 
 _install_packages:
 	$(info [*] Install required packages...)
@@ -140,7 +140,7 @@ ifeq ($(wildcard $(SERVICE)/build/.),)
 endif
 
 _install_deps:
-	$(info [+] Installing '$(SERVICE)' dependencies...")	
+	$(info [+] Installing '$(SERVICE)' dependencies...")
 	@pip install pipenv
 	@$(PIPENV) lock -r > requirements.txt
 	@$(PIPENV) run pip install \
@@ -154,7 +154,7 @@ _package: _clone_service_to_build _check_service_definition _install_deps
 	@$(MAKE) _zip SERVICE="${SERVICE}"
 
 # As its name states: Zip everything up from build
-_zip: _check_dev_definition 
+_zip: _check_dev_definition
 	$(info [+] Creating '$(SERVICE)' ZIP...")
 	@cd ${SERVICE}/build && zip -rq -9 "$(BASE)/$(SERVICE).zip" * \
 	--exclude "wheel/*" "setuptools/*" "pkg_resources/*" "pip/*" \

--- a/{{ cookiecutter.project_name }}/Pipfile
+++ b/{{ cookiecutter.project_name }}/Pipfile
@@ -18,4 +18,4 @@ pytest = "*"
 pytest-cov = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"

--- a/{{ cookiecutter.project_name }}/template.yaml
+++ b/{{ cookiecutter.project_name }}/template.yaml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
     {{ cookiecutter.project_name }}
-    
+
     {{ cookiecutter.project_short_description }}
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
@@ -22,7 +22,7 @@ Resources:
         Properties:
             CodeUri: first_function/build/
             Handler: app.lambda_handler
-            Runtime: python3.6
+            Runtime: python3.8
 {%- if cookiecutter.include_xray == "y" %}
             Tracing: Active {% endif %} # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
 {%- if cookiecutter.include_apigw == "y" %}


### PR DESCRIPTION
*Issue #, if available:* #28 

*Description of changes:*

The goal of this PR is to adjust the target Python version from 3.6 to 3.8.  AWS Lambda and SAM (to include dependent lambci images) now support Python 3.8.  Causation for the change:  This is a cookiecutter project.  As such, it is meant to be used for developing **new** projects versus **existing** projects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
