### PR TITLE
feat(packaging): use Lambda Layer; remove dev deps

### DIFF
--- a/{{ cookiecutter.project_name }}/hello_world/requirements.txt
+++ b/{{ cookiecutter.project_name }}/hello_world/requirements.txt
@@ -1,2 +1,7 @@
-boto3
-aws-lambda-powertools
+# Those dependencies can be omitted:
+# - boto3 is part of Lambda runtime for Python
+# - aws-lambda-powertools is embedded as a layer (see SAM template)
+# This is always a good practice as your lambda packaged code will be much lighter, and it will be invoked quicker
+
+# boto3
+# aws-lambda-powertools

--- a/{{ cookiecutter.project_name }}/template.yaml
+++ b/{{ cookiecutter.project_name }}/template.yaml
@@ -23,6 +23,10 @@ Globals: # https://docs.aws.amazon.com/serverless-application-model/latest/devel
         AutoPublishAlias: live # More info about Safe Deployments: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-deploymentpreference.html
         DeploymentPreference:
             Type: Linear10PercentEvery1Minute {% endif %}
+        # Embed Lambda Powertools as a shared Layer
+        # See: https://awslabs.github.io/aws-lambda-powertools-python/latest/#lambda-layer
+        Layers: # 
+            - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:3
         Environment:
             Variables:
                 # Powertools env vars: https://awslabs.github.io/aws-lambda-powertools-python/#environment-variables

--- a/{{ cookiecutter.project_name }}/template.yaml
+++ b/{{ cookiecutter.project_name }}/template.yaml
@@ -26,7 +26,7 @@ Globals: # https://docs.aws.amazon.com/serverless-application-model/latest/devel
         # Embed Lambda Powertools as a shared Layer
         # See: https://awslabs.github.io/aws-lambda-powertools-python/latest/#lambda-layer
         Layers: # 
-            - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:3
+            - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:6
         Environment:
             Variables:
                 # Powertools env vars: https://awslabs.github.io/aws-lambda-powertools-python/#environment-variables


### PR DESCRIPTION
*Issue:*

I'm a noob with Python, and I struggled a few hours to take benefit from the fact that Lamba Powertools is packaged as a shared layer.

Moreover `boto3` was also packaged with my Lambda function, which gave me a package about 9MB (for a basic single hello-world).

I believe your project template would improve a lot by enforcing good practices:

* do not embed `boto3` but instead rely on the one provided in the Lambda runtime for Python,
* use the global shared Layer for Lamba Powertools

Not sure if that deserves an explanation in the README though. Just tell me.

⚠️ maybe I'm totally wrong with this PR. Again: I'm a complete noob with Python :)
